### PR TITLE
feature(server) Adds user can mark property as sold endpoint

### DIFF
--- a/server/src/v1/routes/properties.js
+++ b/server/src/v1/routes/properties.js
@@ -28,6 +28,6 @@ router.use(verifyAuthUser);
 
 router.post('/', cloudinaryConfig, multerUpload, imageFormatValidator, uploadImage, postPropertyAdValiadator, createPropertyAd);
 router.patch('/:propertyId', verifyExistingProperty, verifyPropertyBelongsToUser, editAdValidator, editPropertyAd);
-
+router.patch('/:propertyId/sold', verifyExistingProperty, verifyPropertyBelongsToUser, markPropertySold);
 
 export default router;

--- a/server/src/v1/tests/properties.test.js
+++ b/server/src/v1/tests/properties.test.js
@@ -324,4 +324,43 @@ describe('properties', () => {
         done(err);
       });
   });
+
+  it('PATCH /:propertyId/sold, should mark a property as sold', (done) => {
+    const newUser = models.User.create({
+      firstName: 'foo',
+      lastName: 'bar',
+      email: 'foo@bar.com',
+      password: 'abcdef',
+    });
+
+    const property = models.Property.create({
+      imageUrl: 'my image 06',
+      address: '4 De Waat Terraces, Goodwood',
+      state: 'Goodwood',
+      city: 'Bulawayo',
+      title: 'One bedroom  in a quiet surburb',
+      description: 'Cosy bedsitter, suitable for singles',
+      price: '$120',
+      type: '1 bedroom',
+      owner: `${newUser.id}`,
+    });
+
+    const myToken = generateToken(newUser.id);
+
+    chai
+      .request(app)
+      .patch(`/api/v1/property/${property.id}/sold`)
+      .set('x-auth-token', myToken)
+      .send({
+        title: '1 bed in Goodwood, TO RENT!',
+      })
+      .end((err, res) => {
+        expect(res).to.have.status(200);
+        expect(res.body.data).to.be.a('object');
+        expect(res.body.data).to.have.key('imageUrl', 'address', 'state', 'city', 'title', 'description', 'price', 'type', 'id', 'status', 'owner', 'createdOn');
+        expect(res.body.data.id).to.be.equal(`${property.id}`);
+        expect(res.body.data.status).to.equal('sold');
+        done(err);
+      });
+  });
 });


### PR DESCRIPTION
#### What does this PR do?
- adds user can mark property as sold endpoint
- adds unit tests to test the added endpoint


#### Description of Task to be completed


#### How should this be manually tested?
- clone this repo
- add a .env file to the root folder and add constants listed in the .env.sample file to it
- on the terminal run  command npm test


#### Any background context you want to provide?
- N/A


#### What are the relevant pivotal tracker stories?
[#167278995](https://www.pivotaltracker.com/n/projects/2370803)

#### Screenshots (if appropriate)