### PR TITLE
feature(server) Create user can delete a property  ad endpoint

### DIFF
--- a/server/src/v1/routes/properties.js
+++ b/server/src/v1/routes/properties.js
@@ -29,5 +29,6 @@ router.use(verifyAuthUser);
 router.post('/', cloudinaryConfig, multerUpload, imageFormatValidator, uploadImage, postPropertyAdValiadator, createPropertyAd);
 router.patch('/:propertyId', verifyExistingProperty, verifyPropertyBelongsToUser, editAdValidator, editPropertyAd);
 router.patch('/:propertyId/sold', verifyExistingProperty, verifyPropertyBelongsToUser, markPropertySold);
+router.delete('/:propertyId', verifyExistingProperty, verifyPropertyBelongsToUser, deletePropertyAd);
 
 export default router;

--- a/server/src/v1/tests/properties.test.js
+++ b/server/src/v1/tests/properties.test.js
@@ -363,4 +363,37 @@ describe('properties', () => {
         done(err);
       });
   });
+
+  it('DELETE /property/:propertyId, should enable a user to delete their own ad', (done) => {
+    const newUser = models.User.create({
+      firstName: 'foo',
+      lastName: 'bar',
+      email: 'foo@bar.com',
+      password: 'abcdef',
+    });
+
+    const newPropertyAd = models.Property.create({
+      imageUrl: 'my image 08',
+      address: '4 De Waat Terraces, Goodwood',
+      state: 'Goodwood',
+      city: 'Bulawayo',
+      title: 'One bedroom  in a quiet surburb',
+      description: 'Cosy bedsitter, suitable for singles',
+      price: '$120',
+      type: '1 bedroom',
+      owner: `${newUser.id}`,
+    });
+
+    const newToken = generateToken(newUser.id);
+
+    chai
+      .request(app)
+      .delete(`/api/v1/property/${newPropertyAd.id}`)
+      .set('x-auth-token', newToken)
+      .end((err, res) => {
+        expect(res).to.have.status(200);
+        expect(res.body.msg).to.be.equal('Property ad is sucessfully deleted');
+        done(err);
+      });
+  });
 });


### PR DESCRIPTION
#### What does this PR do?
- adds user can delete ad endpoint
- adds unit tests to test the  endpoint


#### Description of Task to be completed
- Create a user can delete property ad endpoint and unit test the endpoint


#### How should this be manually tested?
- clone this repo
- add a .env file to your root folder, and add the constants listed in the .env.sample
- on the terminal, run the command npm test


#### Any background context you want to provide?
- N/A


#### What are the relevant pivotal tracker stories?
[#167279268](https://www.pivotaltracker.com/n/projects/2370803)

#### Screenshots (if appropriate)
- N/A