### PR TITLE
feature(server) Create a user can view all ads endpoint

### DIFF
--- a/server/src/v1/routes/properties.js
+++ b/server/src/v1/routes/properties.js
@@ -20,8 +20,7 @@ import { verifyAuthUser, verifyExistingProperty, verifyPropertyBelongsToUser } f
 
 const router = Router();
 
-
-
+router.get('/', fetchAllProperties);
 
 // Auth user all routes for authenticated user/agents
 router.use(verifyAuthUser);

--- a/server/src/v1/tests/properties.test.js
+++ b/server/src/v1/tests/properties.test.js
@@ -396,4 +396,17 @@ describe('properties', () => {
         done(err);
       });
   });
+
+  it('GET /, should get all property ads ', (done) => {
+    chai
+      .request(app)
+      .get('/api/v1/property')
+      .end((err, res) => {
+        expect(res).to.have.status(200);
+        expect(res.body.status).to.equal('success');
+        expect(res.body.data).to.be.a('array');
+        expect(res.body.data.length).to.equal(0);
+        done(err);
+      });
+  });
 });


### PR DESCRIPTION
#### What does this PR do?
- adds user can view all ads endpoint
- adds unit tests to test the endpoint

#### Description of Task to be completed
- Add a user can view all ads endpoint and test it using mocha, chai, and chai-http


#### How should this be manually tested?
- clone this repo
- add a .env file to the root folder, and add all constants listed in the .env.sample
- on the terminal run the command, npm test.


#### Any background context you want to provide?
- N/A

#### What are the relevant pivotal tracker stories?
[#167279333](https://www.pivotaltracker.com/n/projects/2370803)

#### Screenshots (if appropriate)
- N/A