### PR TITLE
feature(server) Create user can view ads of a specific type endpoint

### DIFF
--- a/server/src/v1/routes/properties.js
+++ b/server/src/v1/routes/properties.js
@@ -21,6 +21,7 @@ import { verifyAuthUser, verifyExistingProperty, verifyPropertyBelongsToUser } f
 const router = Router();
 
 router.get('/', fetchAllProperties);
+router.get('/', findAdsOfSpecificType);
 
 // Auth user all routes for authenticated user/agents
 router.use(verifyAuthUser);

--- a/server/src/v1/tests/properties.test.js
+++ b/server/src/v1/tests/properties.test.js
@@ -397,7 +397,7 @@ describe('properties', () => {
       });
   });
 
-  it('GET /, should get all property ads ', (done) => {
+  it('GET /property, should get all property ads ', (done) => {
     chai
       .request(app)
       .get('/api/v1/property')
@@ -409,4 +409,18 @@ describe('properties', () => {
         done(err);
       });
   });
+
+  it('GET /property, should get property ads of a specific type',  (done) => {
+    chai
+      .request(app)
+      .get('/api/v1/property/?type=1%20bedroom')
+      .end((err, res) => {
+        expect(res).to.have.status(200);
+        expect(res.body.status).to.equal('success');
+        expect(res.body.data).to.be.a('array');
+        expect(res.body.data.length).to.be.equal(0);
+        done(err);
+      });
+  });
 });
+


### PR DESCRIPTION
#### What does this PR do?
- adds user can view ads of a specific type
- adds unit tests to test the endpoint

#### Description of Task to be completed
- Create a user can view ads of a specific type endpoint, and test the endpoint using mocha, chai, and chai-http.


#### How should this be manually tested?
- clone this repo
- create a .env file on the root folder, add all constants listed on .env.sample


#### Any background context you want to provide?
- N/A


#### What are the relevant pivotal tracker stories?
[#167279386](https://www.pivotaltracker.com/n/projects/2370803)

#### Screenshots (if appropriate)
- N/A